### PR TITLE
Hoodie url getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,6 @@ on first load, it does not depend on an user account
 
 ### hoodie.url
 
----
-
-🐕 **TO BE DONE**: [#13](https://github.com/hoodiehq/hoodie-client/issues/13)
-
----
-
 Read-only, full url to the hoodie server, e.g. `http://example.com/hoodie`
 
 ### hoodie.account

--- a/index.js
+++ b/index.js
@@ -15,16 +15,19 @@ function Hoodie (options) {
   var api = {
     get id () {
       return id.get(state)
+    },
+    get url () {
+      return state.url + '/hoodie'
     }
   }
 
-  var CustomStore = Store.defaults({ remoteBaseUrl: '/hoodie/store/api' })
+  var CustomStore = Store.defaults({ remoteBaseUrl: api.url + '/store/api' })
   var dbName = 'user/' + api.id
   api.store = new CustomStore(dbName)
 
-  api.account = new Account({ url: '/hoodie/account/api' })
+  api.account = new Account({ url: api.url + '/account/api' })
   api.task = new Task('/hoodie/task/api')
-  api.connectionStatus = new ConnectionStatus('/hoodie')
+  api.connectionStatus = new ConnectionStatus(api.url)
   api.log = new Log('hoodie')
 
   api.on = require('./lib/events').on.bind(this, state)

--- a/lib/get-state.js
+++ b/lib/get-state.js
@@ -7,8 +7,10 @@ var constants = require('./constants')
 var EventEmitter = require('events').EventEmitter
 
 function getState (options) {
+  var url = options && options.url ? options.url : window.location.origin
   return {
     id: config.getItem(constants.CONFIG_KEY_HOODIE_ID),
-    emitter: options && options.emitter || new EventEmitter()
+    emitter: options && options.emitter || new EventEmitter(),
+    url: url
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,2 +1,3 @@
 require('./specs/id')
 require('./specs/events')
+require('./specs/url')

--- a/tests/specs/url.js
+++ b/tests/specs/url.js
@@ -1,0 +1,25 @@
+var test = require('tape')
+var Hoodie = require('../../index')
+
+// Set window.location
+global.window = {
+  location: {
+    origin: 'http://localhost:1234'
+  }
+}
+
+test('has "url" property', function (t) {
+  t.plan(3)
+
+  var defaultHoodie = new Hoodie()
+  var hoodieDefaultUrl = 'http://localhost:1234/hoodie'
+  t.is(typeof defaultHoodie.url, 'string', 'has a url')
+  t.is(defaultHoodie.url, hoodieDefaultUrl, 'url has a default value')
+
+  var exampleUrl = 'http://example.com'
+  var hoodieExampleUrl = exampleUrl + '/hoodie'
+  var specifiedUrlHoodie = new Hoodie({
+    url: exampleUrl
+  })
+  t.is(specifiedUrlHoodie.url, hoodieExampleUrl, 'url is retained after being passed in')
+})


### PR DESCRIPTION
Adding a url property to hoodie api as a getter. The url is passed in as an option and stored in the state. If no url is provided in the options, then the `state.url` will default to window.location.origin. The getter will return the `state.url + /hoodie`. I'm also piping the url through to Account, Store, and Task in the constructor.

To test this I created an object on global called `window` that had a simulated `location.origin`.