### PR TITLE
WIP: hoodie.request

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,12 +157,6 @@ See [log API](https://github.com/hoodiehq/hoodie-client-log#api)
 
 ### hoodie.request
 
----
-
-🐕 **TO BE DONE**: [#9](https://github.com/hoodiehq/hoodie-client/issues/9)
-
----
-
 Sends an http request
 
 ```js

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Hoodie (options) {
 
   api.account = new Account({ url: api.url + '/account/api' })
   api.task = new Task('/hoodie/task/api')
+  api.request = require('./lib/request').bind(this, state)
   api.connectionStatus = new ConnectionStatus(api.url)
   api.log = new Log('hoodie')
   api.plugin = require('./lib/plugin')

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,0 +1,32 @@
+module.exports = request
+
+var Promise = require('lie')
+
+var internals = module.exports.internals = {}
+internals.request = require('./utils/request')
+
+function request (state, options) {
+  if (!state) {
+    return Promise.reject(new Error('hoodie.request: state must be defined'))
+  }
+  if (!options) {
+    return Promise.reject(new Error('hoodie.request: URL or options argument must be defined'))
+  }
+
+  var requestOptions = {
+    url: options.url || options
+  }
+
+  if ((/^\/([^\/]|$)/).test(requestOptions.url)) {
+    requestOptions.url = state.url + requestOptions.url
+  }
+
+  if (options.data) {
+    requestOptions.body = JSON.stringify(options.data)
+  }
+
+  requestOptions.method = options.method
+  requestOptions.headers = options.headers
+
+  return internals.request(requestOptions)
+}

--- a/lib/utils/request.js
+++ b/lib/utils/request.js
@@ -1,0 +1,27 @@
+module.exports = request
+
+var nets = require('nets')
+
+var Promise = require('lie')
+
+function request (options) {
+  options.encoding = undefined
+
+  return new Promise(function (resolve, reject) {
+    nets(options, function (error, response) {
+      if (error) {
+        return reject(error)
+      }
+
+      if (response.statusCode >= 400) {
+        error = new Error('HTTP error ' + response.statusCode)
+        error.name = 'RequestError'
+        error.code = response.statusCode
+        error.body = response.body
+        return reject(error)
+      }
+
+      resolve(response)
+    })
+  })
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "hoodie-client-log": "^1.0.0",
     "hoodie-client-store": "^3.0.0",
     "hoodie-client-task": "^1.0.0",
-    "humble-localstorage": "^1.4.2"
+    "humble-localstorage": "^1.4.2",
+    "lie": "^3.0.1",
+    "nets": "^3.2.0"
   },
   "devDependencies": {
     "browserify": "^12.0.1",
@@ -19,6 +21,7 @@
     "istanbul-coveralls": "^1.0.3",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^1.3.1",
+    "proxyquire": "^1.7.3",
     "rimraf": "^2.4.3",
     "semantic-release": "^4.3.5",
     "simple-mock": "^0.4.1",

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,4 +1,6 @@
 require('./specs/id')
 require('./specs/events')
 require('./specs/url')
+require('./specs/request')
+require('./specs/request-util')
 require('./specs/plugin')

--- a/tests/specs/request-util.js
+++ b/tests/specs/request-util.js
@@ -1,0 +1,79 @@
+var simple = require('simple-mock')
+var test = require('tape')
+var proxyquire = require('proxyquire')
+
+var nets = simple.stub()
+
+var request = proxyquire('../../lib/utils/request', {
+  nets: nets
+})
+
+test('libs/util/request with error', function (t) {
+  t.plan(1)
+
+  var response = {
+    statusCode: 400,
+    body: 'foo'
+  }
+
+  nets.callbackAtIndex(1, {}, response)
+
+  request({})
+
+    .then(t.fail.bind(t, 'must reject'))
+
+    .catch(function (error) {
+      t.is(typeof error, 'object', 'pass original error')
+
+      simple.restore()
+    })
+})
+
+test('libs/util/request with HTTP status < 400', function (t) {
+  t.plan(3)
+
+  var options = {
+    url: '/foo/bar'
+  }
+
+  var response = {
+    statusCode: 200,
+    body: 'foo'
+  }
+
+  nets.callbackAtIndex(1, null, response)
+
+  request(options)
+
+    .then(function (r) {
+      t.deepEqual(nets.lastCall.arg, options)
+      t.is(typeof response, 'object', 'returns response object')
+      t.deepEqual(r, response)
+
+      simple.restore()
+    })
+})
+
+test('libs/util/request with HTTP status >= 400', function (t) {
+  t.plan(4)
+
+  var response = {
+    statusCode: 400,
+    body: 'foo'
+  }
+
+  nets.callbackAtIndex(1, null, response)
+
+  request({url: '/foo/bar'})
+
+    .then(t.fail.bind(t, 'must reject'))
+
+    .catch(function (error) {
+      t.is(typeof error, 'object', 'returns error object')
+      t.deepEqual(error.code, response.statusCode, 'passes HTTP status code as error.code')
+      t.deepEqual(error.name, 'RequestError', 'passes error.name')
+      t.deepEqual(error.body, response.body, 'passes error.body')
+
+      simple.restore()
+    })
+})

--- a/tests/specs/request.js
+++ b/tests/specs/request.js
@@ -1,0 +1,100 @@
+var simple = require('simple-mock')
+var test = require('tape')
+
+var Hoodie = require('../../index')
+
+var request = require('../../lib/request')
+
+var state = Object.freeze({
+  url: 'http://example.com'
+})
+
+test('has "request" method', function (t) {
+  t.plan(1)
+
+  var hoodie = new Hoodie()
+  t.is(typeof hoodie.request, 'function', 'has method')
+})
+
+test('hoodie.request without state object', function (t) {
+  t.plan(1)
+
+  request()
+    .then(t.fail.bind(t, 'must reject'))
+    .catch(t.pass.bind(t, 'rejects with error'))
+})
+
+test('hoodie.request without options', function (t) {
+  t.plan(1)
+
+  request(state)
+    .then(t.fail.bind(t, 'must reject'))
+    .catch(t.pass.bind(t, 'rejects with error'))
+})
+
+test('hoodie.request(url)', function (t) {
+  t.plan(1)
+
+  var requestPath = '/foo/api/bar' // relative URL path
+
+  var expectedURL = state.url + requestPath
+
+  simple.mock(request.internals, 'request').resolveWith({
+    body: 'response body'
+  })
+
+  request(state, requestPath)
+
+    .then(function (response) {
+      t.equal(request.internals.request.lastCall.args[0].url, expectedURL, 'composes URL from state and options if URL begins with /')
+      simple.restore()
+    })
+
+    .catch(t.error)
+})
+
+test('hoodie.request({options})', function (t) {
+  t.plan(2)
+
+  var options = {
+    url: 'http://foo.com/bar', // full URL
+    method: 'POST',
+    data: [1, 2, 3],
+    headers: {foo: 'bar'}
+  }
+
+  simple.mock(request.internals, 'request').resolveWith({
+    body: 'response body'
+  })
+
+  request(state, options)
+
+    .then(function (response) {
+      t.equal(request.internals.request.lastCall.args[0].url, options.url, 'passes URL unmodified when not beginning with /')
+      t.deepEqual(request.internals.request.lastCall.arg, {
+        url: options.url,
+        method: options.method,
+        body: JSON.stringify(options.data),
+        headers: options.headers
+      }, 'formats options for passing to `utils/request`')
+
+      simple.restore()
+    })
+
+    .catch(t.error)
+})
+
+test('hoodie.request with Error', function (t) {
+  t.plan(1)
+
+  simple.mock(request.internals, 'request').rejectWith(new Error('Ooops'))
+
+  request(state, {})
+
+    .then(t.fail.bind(t, 'must reject'))
+
+    .catch(function (error) {
+      t.is(typeof error, 'object', 'returns error object')
+      simple.restore()
+    })
+})


### PR DESCRIPTION
Implemented `hoodie.request` as outlined in the readme and #9, taking cues from `hoodie-client-account` in deps and code style.

Look OK?

closes #9