### PR TITLE
Call reset instead of clear on signout

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -8,12 +8,12 @@ function init (hoodie) {
   account.on('signout', function () {
     // TODO: prevent data loss on sign out:
     //       https://github.com/hoodiehq/hoodie-client/issues/22
-    store.clear()
+    store.reset({ name: hoodie.account.id })
   })
 
   account.on('signin', function () {
-    store.reset().then(
-      store.connect
-    )
+    store
+      .reset({ name: hoodie.account.id })
+      .then(store.connect)
   })
 }

--- a/tests/specs/init.js
+++ b/tests/specs/init.js
@@ -3,22 +3,22 @@ var test = require('tape')
 var init = require('../../lib/init')
 
 test('is "reset" triggered on "signin"', function (t) {
-  t.plan(5)
+  t.plan(6)
 
   var signInTestOrder = []
   var hoodie = {
     account: {
+      id: 0,
       on: simple.stub()
     },
     store: {
-      clear: function () {
-        t.pass('store.clear called on "signout"')
-      },
       connect: function () {
         t.pass('store.connect is called on "signin"')
         signInTestOrder.push('connect')
       },
-      reset: function () {
+      reset: function (options) {
+        t.isNot(typeof options, 'undefined', 'store.reset options are defined')
+        t.isNot(typeof options.name, 'undefined', 'store.reset options has defined name')
         t.pass('store.reset called on "signin"')
         signInTestOrder.push('reset')
 
@@ -32,13 +32,34 @@ test('is "reset" triggered on "signin"', function (t) {
   }
 
   init(hoodie)
-  t.is(hoodie.account.on.callCount, 2, 'calls hoodie account.on twice')
-
-  var signOutHandler = hoodie.account.on.calls[0].args[1]
-  signOutHandler()
+  t.is(hoodie.account.on.callCount, 2, 'calls hoodie account.on once')
 
   var signInHandler = hoodie.account.on.calls[1].args[1]
   signInHandler()
 
   t.deepEqual(signInTestOrder, ['reset', 'connect'], 'store.connect was called after store.reset')
+})
+
+test('is "reset" triggered on "signout"', function (t) {
+  t.plan(4)
+
+  var hoodie = {
+    account: {
+      id: 0,
+      on: simple.stub()
+    },
+    store: {
+      reset: function (options) {
+        t.isNot(typeof options, 'undefined', 'store.reset options are defined')
+        t.isNot(typeof options.name, 'undefined', 'store.reset options has defined name')
+        t.pass('store.reset called on "signout"')
+      }
+    }
+  }
+
+  init(hoodie)
+  t.is(hoodie.account.on.callCount, 2, 'calls hoodie account.on once')
+
+  var signOutHandler = hoodie.account.on.calls[0].args[1]
+  signOutHandler()
 })


### PR DESCRIPTION
closes #44 

Out of curiosity why does hoodie.account.id change on signout?