### PR TITLE
Hoodie account client/91/signout sync error

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -55,6 +55,14 @@ function init (hoodie) {
   hoodie.account.on('pre:signout', function (options) {
     options.hooks.push(function () {
       return hoodie.store.push()
+      .catch(function (error) {
+        if (error.status !== 401) {
+          throw error
+        }
+
+        error.message = 'Local changes could not be synced, sign in first'
+        throw error
+      })
     })
   })
   hoodie.account.on('post:signout', function (options) {

--- a/tests/specs/init.js
+++ b/tests/specs/init.js
@@ -210,6 +210,7 @@ test('"hoodie.store.push" is called on "pre:signout"', function (t) {
     store: {
       push: function () {
         t.pass('store.push called on "signout"')
+        return {catch: function () {}}
       }
     },
     connectionStatus: {

--- a/tests/specs/init.js
+++ b/tests/specs/init.js
@@ -225,6 +225,37 @@ test('"hoodie.store.push" is called on "pre:signout"', function (t) {
   hooks[0]()
 })
 
+test('"hoodie.store.push" returns better error message if local changes cannot be synced', function (t) {
+  t.plan(2)
+
+  var UnauthorizedError = new Error('unauthorized')
+  UnauthorizedError.status = 401
+
+  var hoodie = {
+    account: {
+      id: 0,
+      on: simple.stub(),
+      isSignedIn: simple.stub()
+    },
+    store: {
+      push: simple.stub().rejectWith(UnauthorizedError)
+    },
+    connectionStatus: {
+      on: simple.stub()
+    }
+  }
+
+  init(hoodie)
+  var signOutHandler = findEventHandler(hoodie.account.on.calls, 'pre:signout')
+  var hooks = []
+  signOutHandler({hooks: hooks})
+  t.is(hooks.length, 1, 'one pre:signout hook registered')
+  hooks[0]()
+    .catch(function (error) {
+      t.is(error.message, 'Local changes could not be synced, sign in first')
+    })
+})
+
 test('"hoodie.store.*" is *not* called when "hoodie.account.isSignedIn()" returns "false"', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
closes https://github.com/hoodiehq/hoodie-account-client/issues/91

~~One thing to note is test for hoodie.store.push https://github.com/hoodiehq/hoodie-client/blob/master/tests/specs/init.js#L201-L226 is now failing because of a change in init.js.~~

~~I have the fix, but wondering whether or not it's supposed to be included with this PR?~~
Pushed new commit to fix failing test.