### PR TITLE
drop localStorage usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,28 @@ new Hoodie(options)
   </tr>
 </table>
 
+### hoodie.ready
+
+_Read-only_
+
+```js
+hoodie.ready
+```
+
+Promise that resolves once the hoodie API is fully initialised.
+
+Things like the the username or session ID are persisted in the local store and
+have to be loaded before APIs like `hoodie.account.id` can be used. It’s
+therefore necessary to wait until the hoodie API is ready before using it
+
+```js
+hoodie.ready.then(function () {
+  if (hoodie.account.isSignedIn()) {
+    alert('Welcome, ' + hoodie.account.username)
+  }
+})
+```
+
 ### hoodie.url
 
 _Read-only_

--- a/index.js
+++ b/index.js
@@ -2,11 +2,10 @@ module.exports = Hoodie
 
 var getState = require('./lib/get-state')
 var getApi = require('./lib/get-api')
-var init = require('./lib/init')
 
 function Hoodie (options) {
   var state = getState(options)
   var api = getApi(state)
-  init(api)
+
   return api
 }

--- a/lib/get-api.js
+++ b/lib/get-api.js
@@ -1,4 +1,3 @@
-
 module.exports = getApi
 
 var defaultsDeep = require('lodash/defaultsDeep')
@@ -8,50 +7,100 @@ internals.Store = require('@hoodie/store-client')
 internals.Account = require('@hoodie/account-client')
 internals.ConnectionStatus = require('@hoodie/connection-status/client')
 internals.Log = require('@hoodie/log/client')
+internals.pouchdbDocApi = require('pouchdb-doc-api')
+
+internals.init = require('./init')
 
 function getApi (state) {
+  var url = state.url + '/hoodie'
+
+  state.PouchDB.plugin(internals.pouchdbDocApi)
+  var hoodieDb = new state.PouchDB('hoodie')
+
+  var hoodieAccount = mergeOptionsAndCreate(internals.Account, {
+    cache: hoodieDb.doc('_local/account'),
+    url: url + '/account/api'
+  }, state.account)
+
+  var hoodieConnectionStatus = mergeOptionsAndCreate(internals.ConnectionStatus, {
+    cache: hoodieDb.doc('_local/connection-status'),
+    url: url
+  }, state.connectionStatus)
+  var log = mergeOptionsAndCreate(internals.Log, { prefix: 'hoodie' }, state.log)
+
+  var hoodieStore
+  var isReady = false
   var api = {
     get url () {
       return state.url + '/hoodie'
-    }
+    },
+    get ready () {
+      return Promise.all([hoodieAccount.ready, hoodieConnectionStatus.ready])
+
+      .then(function () {
+        isReady = true
+        var CustomPouchDB = state.PouchDB.defaults({
+          ajax: {
+            headers: {
+              get authorization () {
+                var session = api.account.get('session')
+                if (!session) {
+                  return
+                }
+
+                return 'Session ' + session.id
+              }
+            }
+          }
+        })
+        var CustomStore = internals.Store.defaults({
+          PouchDB: CustomPouchDB,
+          remoteBaseUrl: url + '/store/api'
+        })
+        var dbName = 'user/' + hoodieAccount.id
+        hoodieStore = new CustomStore(dbName)
+
+        internals.init(api)
+
+        return api
+      })
+    },
+
+    // core modules
+    get account () {
+      if (!isReady) {
+        throw new Error('hoodie.account not yet accessible, wait for hoodie.ready to resolve')
+      }
+
+      return hoodieAccount
+    },
+    get store () {
+      if (!isReady) {
+        throw new Error('hoodie.store not yet accessible, wait for hoodie.ready to resolve')
+      }
+
+      return hoodieStore
+    },
+    get connectionStatus () {
+      if (!isReady) {
+        throw new Error('hoodie.connectionStatus not yet accessible, wait for hoodie.ready to resolve')
+      }
+
+      return hoodieConnectionStatus
+    },
+
+    // helpers
+    request: require('./request').bind(this, state),
+    log: log,
+    plugin: require('./plugin'),
+
+    // events
+    on: require('./events').on.bind(this, state),
+    one: require('./events').one.bind(this, state),
+    off: require('./events').off.bind(this, state),
+    trigger: require('./events').trigger.bind(this, state)
   }
 
-  var account = mergeOptionsAndCreate(internals.Account, { url: api.url + '/account/api' }, state.account)
-  var CustomPouchDB = state.PouchDB.defaults({
-    ajax: {
-      headers: {
-        get authorization () {
-          var session = account.get('session')
-          if (!session) {
-            return
-          }
-
-          return 'Session ' + session.id
-        }
-      }
-    }
-  })
-
-  var CustomStore = internals.Store.defaults({
-    PouchDB: CustomPouchDB,
-    remoteBaseUrl: api.url + '/store/api'
-  })
-  var dbName = 'user/' + account.id
-  var store = new CustomStore(dbName)
-
-  // core modules
-  api.account = account
-  api.store = store
-  api.request = require('./request').bind(this, state)
-  api.connectionStatus = mergeOptionsAndCreate(internals.ConnectionStatus, { url: api.url }, state.connectionStatus)
-  api.log = mergeOptionsAndCreate(internals.Log, { prefix: 'hoodie' }, state.log)
-  api.plugin = require('./plugin')
-
-  // events
-  api.on = require('./events').on.bind(this, state)
-  api.one = require('./events').one.bind(this, state)
-  api.off = require('./events').off.bind(this, state)
-  api.trigger = require('./events').trigger.bind(this, state)
   return api
 }
 

--- a/lib/get-state.js
+++ b/lib/get-state.js
@@ -1,11 +1,8 @@
 module.exports = getState
 
-var config = require('humble-localstorage')
 var EventEmitter = require('events').EventEmitter
 
 var defaultsDeep = require('lodash/defaultsDeep')
-
-var constants = require('./constants')
 
 function getState (options) {
   options = options || {}
@@ -18,7 +15,6 @@ function getState (options) {
   }
 
   var requiredProperties = {
-    id: config.getItem(constants.CONFIG_KEY_HOODIE_ID),
     emitter: options && options.emitter || new EventEmitter()
   }
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -3,72 +3,54 @@ module.exports = init
 function init (hoodie) {
   // In order to prevent data loss, we want to move all data that has been
   // created without an account (e.g. while offline) to the user’s account
-  // on signin. So before the signin happens, we temporarily store it in
-  // a variable (dataFromAccountBeforeSignin) and add it to the store again
-  // in the post:signin hook below
-  var dataFromAccountBeforeSignin
-  var accountIdBeforeSignIn
-  hoodie.account.on('pre:signin', function (options) {
-    options.hooks.push(function () {
-      accountIdBeforeSignIn = hoodie.account.id
-      return hoodie.store.findAll().then(function (objects) {
-        dataFromAccountBeforeSignin = objects
-      })
+  // on signin. So before the signin happens, we store the user account’s id
+  // and data and store it again after the signin
+  hoodie.account.hook.before('signin', function (options) {
+    options.beforeSignin = {
+      accountId: hoodie.account.id
+    }
+    return hoodie.store.findAll().then(function (docs) {
+      options.beforeSignin.docs = docs
     })
   })
 
-  hoodie.account.on('post:signin', function (options) {
-    options.hooks.push(function () {
-      // when signing in to a newly created account, the account.id
-      // does not change, so there is no need to clear the local
-      // store and to migrate data
-      if (accountIdBeforeSignIn === hoodie.account.id) {
-        dataFromAccountBeforeSignin = null
-        return hoodie.store.connect()
+  hoodie.account.hook.after('signin', function (session, options) {
+    // when signing in to a newly created account, the account.id does not
+    // change. The same is true when the user changed their username. In both
+    // cases there is no need to migrate local data
+    if (options.beforeSignin.accountId === hoodie.account.id) {
+      return hoodie.store.connect()
+    }
+
+    return hoodie.store.reset({ name: 'user/' + hoodie.account.id })
+
+    .then(function () {
+      function migrate (doc) {
+        doc.createdBy = hoodie.account.id
+        delete doc._rev
+        return doc
+      }
+      return hoodie.store.add(options.beforeSignin.docs.map(migrate))
+    })
+
+    .then(function () {
+      return hoodie.store.connect()
+    })
+  })
+
+  hoodie.account.hook.before('signout', function () {
+    return hoodie.store.push()
+    .catch(function (error) {
+      if (error.status !== 401) {
+        throw error
       }
 
-      return hoodie.store.reset({ name: 'user/' + hoodie.account.id })
-
-      .catch(function (error) {
-        dataFromAccountBeforeSignin = null
-        throw error
-      })
-
-      .then(function () {
-        var migratedDataFromAccountBeforeSignIn = dataFromAccountBeforeSignin.map(function (object) {
-          object.createdBy = hoodie.account.id
-          delete object._rev
-          return object
-        })
-        dataFromAccountBeforeSignin = null
-        return hoodie.store.add(migratedDataFromAccountBeforeSignIn)
-      })
-
-      .then(function () {
-        return hoodie.store.connect()
-      })
+      error.message = 'Local changes could not be synced, sign in first'
+      throw error
     })
   })
-
-  // see https://github.com/hoodiehq/hoodie-client-account/issues/65
-  // for info on the internal pre:* & post:* events
-  hoodie.account.on('pre:signout', function (options) {
-    options.hooks.push(function () {
-      return hoodie.store.push()
-      .catch(function (error) {
-        if (error.status !== 401) {
-          throw error
-        }
-
-        error.message = 'Local changes could not be synced, sign in first'
-        throw error
-      })
-    })
-  })
-  hoodie.account.on('post:signout', function (options) {
-    options.hooks.push(function () {
-      return hoodie.store.reset({ name: 'user/' + hoodie.account.id })
-    })
+  hoodie.account.hook.after('signout', function (options) {
+    return hoodie.store.reset({ name: 'user/' + hoodie.account.id })
   })
 
   hoodie.account.on('unauthenticate', hoodie.store.disconnect)

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
     "url": "https://github.com/hoodiehq/hoodie-client/issues"
   },
   "dependencies": {
-    "@hoodie/account-client": "^4.4.0",
-    "@hoodie/connection-status": "^3.0.0",
+    "@hoodie/account-client": "^5.0.0",
+    "@hoodie/connection-status": "^4.0.1",
     "@hoodie/log": "^2.1.0",
-    "@hoodie/store-client": "^6.0.2",
-    "humble-localstorage": "^1.4.2",
+    "@hoodie/store-client": "^7.0.0",
     "lie": "^3.0.1",
     "lodash": "^4.11.1",
     "nets": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "humble-localstorage": "^1.4.2",
     "lie": "^3.0.1",
     "lodash": "^4.11.1",
-    "nets": "^3.2.0"
+    "nets": "^3.2.0",
+    "pouchdb-doc-api": "^1.0.0"
   },
   "devDependencies": {
     "browserify": "^13.0.0",


### PR DESCRIPTION
📋  part of https://github.com/hoodiehq/camp/issues/101. closes #116, closes #117, closes #118 

---

This hurts me a bit, because the API becomes more complex as it is today. Instead of just doing

```js
if (hoodie.account.isSignedIn()) {
  alert('Welcome, ' + hoodie.account.username)
}
```

we now have to do 

```js
hoodie.ready.then(function () {
  if (hoodie.account.isSignedIn()) {
    alert('Welcome, ' + hoodie.account.username)
  }
})
```

We could only support the synchronous API without a bootstrapping because we relied on the synchronous APIs of `localStorage`. We decided that we have to drop that dependency if we want hoodie to run in other environments where localStorage is not available, like Service Worker, Node.js or native environments like React Native or Electron. 

On the plus side, once `hoodie.ready` is resolved, the API remains as it is today, and we can expose a hook which would allow plugins for asynchronous initialisation, too. 

### Progress

- [x] (#112) use account.hook API
- [x] use `@hoodie/client-account`’s `options.cache` for async storage
- [x] use `@hoodie/connection-status`’ `options.cache` for async storage
- [x] add `hoodie.ready` API which waits for the `account.ready` and `connectionStatus.ready` to resolve
- [x] release breaking versions of `@hoodie/client-account` and `@hoodie/connection-status` and update `@hoodie/client`’s `package.json`

### BREAKING CHANGE:

Hoodie dropped its dependency on localStorage in order to work in non-browser environments. In order to make that work we have to use async store APIs to load the current state like the session id, username or the connection status.

The APIs `hoodie.account`, `hoodie.store` and `hoodie.connectionStatus` can now only be used after the promise returned by `hoodie.ready` resolves.