### PR TITLE
session header fix

### DIFF
--- a/lib/get-api.js
+++ b/lib/get-api.js
@@ -21,7 +21,7 @@ function getApi (state) {
     ajax: {
       headers: {
         get authorization () {
-          var session = api.account.get('session')
+          var session = account.get('session')
           if (!session) {
             return
           }


### PR DESCRIPTION
Store starts replicating before the full hoodie client API is available, so we use the `account` instance directly which is initialised above