### PR TITLE
hoodie.ready fix

### DIFF
--- a/lib/get-api.js
+++ b/lib/get-api.js
@@ -35,7 +35,7 @@ function getApi (state) {
     },
     get ready () {
       if (state.isReady) {
-        return api
+        return Promise.resolve(api)
       }
 
       return Promise.all([hoodieAccount.ready, hoodieConnectionStatus.ready])


### PR DESCRIPTION
Once the hoodie setup finishes, `hoodie.ready` returns the api instead of resolving with it. Oops. Time to get to proper test coverage to avoid things like this in future ...