### PR TITLE
fix: `hoodie.trigger()` should accept optional arguments

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -48,10 +48,19 @@ function off (state, eventName, handler) {
 /**
  * trigger a specified event
  *
- * @param  {String} eventName   Name of event
+ * @param  {String} eventName    Name of event
+ * @param  {...*} [options]      Options
  */
 function trigger (state, eventName) {
-  state.emitter.emit(eventName)
+  var emitter = state.emitter
+  var len = arguments.length
+  var args = Array(len - 1)
+
+  for (var i = 0; i < len - 1; i++) {
+    args[i] = arguments[i + 1]
+  }
+
+  emitter.emit.apply(emitter, args)
 
   return this
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -52,15 +52,9 @@ function off (state, eventName, handler) {
  * @param  {...*} [options]      Options
  */
 function trigger (state, eventName) {
-  var emitter = state.emitter
-  var len = arguments.length
-  var args = Array(len - 1)
+  var args = [].slice.call(arguments, 1)
 
-  for (var i = 0; i < len - 1; i++) {
-    args[i] = arguments[i + 1]
-  }
-
-  emitter.emit.apply(emitter, args)
+  state.emitter.emit.apply(state.emitter, args)
 
   return this
 }

--- a/tests/specs/events.js
+++ b/tests/specs/events.js
@@ -131,16 +131,22 @@ test('"trigger" returns an object', function (t) {
 })
 
 test('"trigger" accepts optional arguments', function (t) {
-  t.plan(1)
+  t.plan(3)
 
   var hoodie = new Hoodie({
     PouchDB: PouchDBMock,
     url: 'http://localhost:1234/hoodie'
   })
 
-  hoodie.on('account:signin', function (options) {
-    t.is(typeof options, 'object', 'accepts optional arguments')
+  var option1 = 'option1'
+  var option2 = 'option2'
+  var option3 = 'option3'
+
+  hoodie.on('account:signin', function () {
+    t.equal(arguments[0], option1, 'receives the first argument')
+    t.equal(arguments[1], option2, 'receives the second argument')
+    t.equal(arguments[2], option3, 'receives the third argument')
   })
 
-  hoodie.trigger('account:signin', {})
+  hoodie.trigger('account:signin', option1, option2, option3)
 })

--- a/tests/specs/events.js
+++ b/tests/specs/events.js
@@ -129,3 +129,18 @@ test('"trigger" returns an object', function (t) {
 
   t.is(typeof hoodie.trigger('account:signin'), 'object', 'returns an object')
 })
+
+test('"trigger" accepts optional arguments', function (t) {
+  t.plan(1)
+
+  var hoodie = new Hoodie({
+    PouchDB: PouchDBMock,
+    url: 'http://localhost:1234/hoodie'
+  })
+
+  hoodie.on('account:signin', function (options) {
+    t.is(typeof options, 'object', 'accepts optional arguments')
+  })
+
+  hoodie.trigger('account:signin', {})
+})


### PR DESCRIPTION
Trying to fix #156.